### PR TITLE
Update code.user.js

### DIFF
--- a/code.user.js
+++ b/code.user.js
@@ -205,7 +205,7 @@
                 pop_job_tooltip: !0,
                 mw_clear_time: 15552e6,
                 mw_scan_limit: 50,
-                mw_enabled: !("https://events.the-west.net" === Game.masterURL),
+                mw_enabled: !1,
                 mw_buyouts_only: !1,
                 mw_item_price_tooltip: !0,
                 mw_product_price_tooltip: !0,


### PR DESCRIPTION
Two factors

First, it's prohibited to use MarketWatcher, not to use any other feature in TWIR.
So, I think it's better to have this disabled unless the user want to.

Second, sometimes, this feature block me from using for some minutes because the soft ban.
I know the cause and the issue, but who doesn't know, could be frustrated by using this.
And could be good to put this feature not only disabled, but with a warning saying that may cause soft ban.